### PR TITLE
feat: add Smart RO CulliganIoT device class

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "culligan"
-version = "1.1.5"
+version = "1.1.6"
 authors = [
   { name="Reward One", email="rewardone@gmail.com" },
 ]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,3 @@
 [pytest]
 asyncio_mode=strict
+asyncio_default_fixture_loop_scope=function

--- a/src/culligan/__init__.py
+++ b/src/culligan/__init__.py
@@ -9,4 +9,4 @@ from .exc import (
     CulliganReadOnlyPropertyError,
 )
 
-__version__ = '1.1.5'
+__version__ = '1.1.6'

--- a/src/culligan/culliganiot_device.py
+++ b/src/culligan/culliganiot_device.py
@@ -130,6 +130,40 @@ class CulliganIoTDevice:
         return True
 
     
+class CulliganIoTRO(CulliganIoTDevice):
+    """Read-only Smart RO / reverse-osmosis device entity."""
+
+    def __init__(self, culligan_api: "CulliganApi", device_dct: Dict):
+        super().__init__(culligan_api, device_dct)
+
+        self._model                     = device_dct.get("model")
+        self._generation                = device_dct.get("generation")
+        self._software_version          = device_dct.get("swVersion")
+        self._region                    = device_dct.get("region", {}).get("code")
+
+        self.is_online                  = bool(device_dct.get("status", {}).get("connection", {}).get("online"))
+
+        # Command semantics for RO devices are not defined yet. Keep this class
+        # intentionally read-only until the cloud API surface is understood.
+        self._commands                  = []
+
+    @property
+    def device_model_number(self) -> Optional[str]:
+        return self._model
+
+    @property
+    def generation(self):
+        return self._generation
+    
+    @property
+    def software_version(self):
+        return self._software_version
+    
+    @property
+    def region(self):
+        return self._region
+    
+
 class CulliganIoTSoftener(CulliganIoTDevice):
     """ Extend device into a water softener specific device """
 

--- a/src/culligan/culliganiot_device.py
+++ b/src/culligan/culliganiot_device.py
@@ -29,7 +29,7 @@ class CulliganIoTDevice:
         # Properties
         self._name                  = device_dct['name']
         self._device_serial_number  = device_dct["serialNumber"]
-        
+
         # provide _dsn to prevent refactoring of upstream code in Culligan Integration
         self._dsn                   = self._device_serial_number
         self._error                 = None
@@ -45,12 +45,12 @@ class CulliganIoTDevice:
     @property
     def name(self):
         return self._name
-    
+
     @property
     def command_endpoint(self) -> str:
         """The endpoint which processes action commands"""
         return f"{CULLIGAN_IOT_URL:s}/device/command"
-    
+
     def set_command_payload(self, command: str, active: Optional[bool], duration: Optional[int]=60) -> dict:
         """"""
         if command in self._commands:
@@ -71,7 +71,7 @@ class CulliganIoTDevice:
                     payload["params"]["duration"] = duration
 
             return payload
-    
+
     @property
     def all_properties_endpoint(self) -> str:
         """
@@ -79,7 +79,7 @@ class CulliganIoTDevice:
             This API retrieves all the properties for a specified device serial number (DSN).
         """
         return f'{CULLIGAN_IOT_URL}/device/data?serialNumber={self.device_serial_number}'
-    
+
     def get_property_value(self, property_name: PropertyName) -> Any:
         """Get the value of a property from the properties dictionary"""
         if isinstance(property_name, Enum):
@@ -93,7 +93,7 @@ class CulliganIoTDevice:
 
         resp = self.culligan_api.self_request('get', self.all_properties_endpoint, params=None)
         properties = resp.json()
-        
+
         return self._do_update(full_update, properties)
 
     async def async_update(self, property_list: Optional[Iterable[str]] = None):
@@ -129,7 +129,7 @@ class CulliganIoTDevice:
 
         return True
 
-    
+
 class CulliganIoTRO(CulliganIoTDevice):
     """Read-only Smart RO / reverse-osmosis device entity."""
 
@@ -154,15 +154,15 @@ class CulliganIoTRO(CulliganIoTDevice):
     @property
     def generation(self):
         return self._generation
-    
+
     @property
     def software_version(self):
         return self._software_version
-    
+
     @property
     def region(self):
         return self._region
-    
+
 
 class CulliganIoTSoftener(CulliganIoTDevice):
     """ Extend device into a water softener specific device """
@@ -186,15 +186,15 @@ class CulliganIoTSoftener(CulliganIoTDevice):
     @property
     def generation(self):
         return self._generation
-    
+
     @property
     def software_version(self):
         return self._software_version
-    
+
     @property
     def region(self):
         return self._region
-    
+
     def get_telemetry(self):
         """Send telemetry command"""
         resp = self.culligan_api.self_request('post', self.command_endpoint, json=self.set_command_payload("telemetry.get", True))
@@ -203,7 +203,7 @@ class CulliganIoTSoftener(CulliganIoTDevice):
             return True
         else:
             return False
-        
+
     async def async_get_telemetry(self):
         """Send telemetry command"""
         resp = await self.culligan_api.async_request('post', self.command_endpoint, json=self.set_command_payload("telemetry.get", True))
@@ -212,7 +212,7 @@ class CulliganIoTSoftener(CulliganIoTDevice):
             return True
         else:
             return False
-        
+
     def start_vacation_mode(self):
         """Send telemetry command"""
         resp = self.culligan_api.self_request('post', self.command_endpoint, json=self.set_command_payload("awayMode.set", True))
@@ -221,7 +221,7 @@ class CulliganIoTSoftener(CulliganIoTDevice):
             return True
         else:
             return False
-        
+
     async def async_start_vacation_mode(self):
         """Send telemetry command"""
         resp = await self.culligan_api.async_request('post', self.command_endpoint, json=self.set_command_payload("awayMode.set", True))
@@ -230,7 +230,7 @@ class CulliganIoTSoftener(CulliganIoTDevice):
             return True
         else:
             return False
-        
+
     def stop_vacation_mode(self):
         """Send telemetry command"""
         resp = self.culligan_api.self_request('post', self.command_endpoint, json=self.set_command_payload("awayMode.set", False))
@@ -239,7 +239,7 @@ class CulliganIoTSoftener(CulliganIoTDevice):
             return True
         else:
             return False
-        
+
     async def async_stop_vacation_mode(self):
         """Send telemetry command"""
         resp = await self.culligan_api.async_request('post', self.command_endpoint, json=self.set_command_payload("awayMode.set", False))
@@ -248,7 +248,7 @@ class CulliganIoTSoftener(CulliganIoTDevice):
             return True
         else:
             return False
-    
+
     def start_bypass_mode(self):
         """Send telemetry command"""
         resp = self.culligan_api.self_request('post', self.command_endpoint, json=self.set_command_payload("bypass.permanent.on", True))
@@ -257,7 +257,7 @@ class CulliganIoTSoftener(CulliganIoTDevice):
             return True
         else:
             return False
-        
+
     async def async_start_bypass_mode(self):
         """Send telemetry command"""
         resp = await self.culligan_api.async_request('post', self.command_endpoint, json=self.set_command_payload("bypass.permanent.on", True))
@@ -266,7 +266,7 @@ class CulliganIoTSoftener(CulliganIoTDevice):
             return True
         else:
             return False
-        
+
     def start_bypass_timed_mode(self, duration: int=60):
         """Send telemetry command"""
         resp = self.culligan_api.self_request('post', self.command_endpoint, json=self.set_command_payload("bypass.timed.on", True, duration))
@@ -275,7 +275,7 @@ class CulliganIoTSoftener(CulliganIoTDevice):
             return True
         else:
             return False
-        
+
     async def async_start_bypass_timed_mode(self, duration: int=60):
         """Send telemetry command"""
         resp = await self.culligan_api.async_request('post', self.command_endpoint, json=self.set_command_payload("bypass.permanent.on", True, duration))
@@ -284,7 +284,7 @@ class CulliganIoTSoftener(CulliganIoTDevice):
             return True
         else:
             return False
-        
+
     def stop_bypass_mode(self):
         """Send telemetry command"""
         resp = self.culligan_api.self_request('post', self.command_endpoint, json=self.set_command_payload("bypass.off", True))
@@ -293,7 +293,7 @@ class CulliganIoTSoftener(CulliganIoTDevice):
             return True
         else:
             return False
-        
+
     async def async_stop_bypass_mode(self):
         """Send telemetry command"""
         resp = await self.culligan_api.async_request('post', self.command_endpoint, json=self.set_command_payload("bypass.off", True))

--- a/src/culligan/uniapi_culliganiot.py
+++ b/src/culligan/uniapi_culliganiot.py
@@ -10,7 +10,7 @@ Others such as /devices.json only seem to work when obtaining the token through 
 
 from aiohttp    import ClientSession             # async http
 from ayla_iot_unofficial import AylaApi
-from .culliganiot_device import CulliganIoTDevice, CulliganIoTSoftener
+from .culliganiot_device import CulliganIoTDevice, CulliganIoTRO, CulliganIoTSoftener
 from datetime   import datetime, timedelta       # datetime operations
 from requests   import post, put, request, Response   # http request library
 from typing     import Dict, List, Optional      # object types
@@ -36,6 +36,31 @@ from .exc import (
 )
 
 _session = None
+
+
+def is_culligan_iot_ro(device: Dict) -> bool:
+    """Return true when a CulliganIoT registry device is a Smart RO device."""
+    name = str(device.get("name", "")).casefold()
+    model = str(device.get("model", "")).casefold()
+    serial_number = str(device.get("serialNumber", "")).casefold()
+    return (
+        "smart ro" in name
+        or "reverse osmosis" in name
+        or model.startswith("sro")
+        or serial_number.startswith("sro")
+    )
+
+
+def culligan_iot_device_from_registry(api: "CulliganApi", device: Dict) -> CulliganIoTDevice:
+    """Build the most specific CulliganIoT device class known for a registry device."""
+    # Have no idea what products will be enabled or how to identify them ... for now ... Smart HE is a softener
+    if device["name"] in ["Smart HE", "Smart Modernity"]:
+        return CulliganIoTSoftener(api, device)
+    if is_culligan_iot_ro(device):
+        return CulliganIoTRO(api, device)
+    # Everything else is a device
+    return CulliganIoTDevice(api, device)
+
 
 def new_culligan_api(username: str, password: str, app_id: str = CULLIGAN_APP_ID, websession: Optional[ClientSession] = None):
     """Get an CulliganApi object. Username is an email address."""
@@ -345,12 +370,7 @@ class CulliganApi:
         devices = list()
         device_registry = self.get_device_registry()
         for d in device_registry["data"]["devices"]:
-            # Have no idea what products will be enabled or how to identify them ... for now ... Smart HE is a softener
-            if   d["name"] in ["Smart HE","Smart Modernity"]:
-                devices.append(CulliganIoTSoftener(self, d))
-            # Everything else is a device
-            else:
-                devices.append(CulliganIoTDevice  (self, d))
+            devices.append(culligan_iot_device_from_registry(self, d))
         return devices
     
     async def async_get_devices(self) -> List[CulliganIoTDevice]:
@@ -358,12 +378,7 @@ class CulliganApi:
         devices = list()
         device_registry = await self.async_get_device_registry()
         for d in device_registry["data"]["devices"]:
-            # Have no idea what products will be enabled or how to identify them ... for now ... Smart HE is a softener
-            if   d["name"] in ["Smart HE","Smart Modernity"]:
-                devices.append(CulliganIoTSoftener(self, d))
-            # Everything else is a device
-            else:
-                devices.append(CulliganIoTDevice  (self, d))
+            devices.append(culligan_iot_device_from_registry(self, d))
         return devices
 
     def get_device_data(self, serialNumber: str) -> Dict[str, str]:

--- a/tests/test_culligan_iot_ro.py
+++ b/tests/test_culligan_iot_ro.py
@@ -1,0 +1,83 @@
+import asyncio
+
+from culligan.culliganiot_device import CulliganIoTDevice, CulliganIoTRO, CulliganIoTSoftener
+from culligan.uniapi_culliganiot import CulliganApi
+
+
+def _smart_ro_registry_device(**overrides):
+    device = {
+        "serialNumber": "SRO1-0000AC000W024945974",
+        "name": "Smart RO",
+        "model": "SRO1",
+        "generation": "1",
+        "protocolVersion": 1,
+        "swVersion": "1.2.3",
+        "status": {"connection": {"online": True, "lastUpdate": "2026-05-12T00:00:00Z"}},
+        "region": {"code": "US"},
+    }
+    device.update(overrides)
+    return device
+
+
+def _smart_he_registry_device():
+    return {
+        "serialNumber": "GBX2-HPRT979WPFARU4HZRMU",
+        "name": "Smart HE",
+        "model": "Smart HE gbx2",
+        "generation": "2",
+        "protocolVersion": 1,
+        "swVersion": "2.3.4",
+        "status": {"connection": {"online": True, "lastUpdate": "2026-05-12T00:00:00Z"}},
+        "region": {"code": "US"},
+    }
+
+
+def _api_with_registry(devices):
+    api = object.__new__(CulliganApi)
+    api.get_device_registry = lambda: {"data": {"devices": devices}}
+
+    async def async_get_device_registry():
+        return {"data": {"devices": devices}}
+
+    api.async_get_device_registry = async_get_device_registry
+    return api
+
+
+def test_culligan_iot_ro_is_read_only_device_type():
+    api = object()
+    device = CulliganIoTRO(api, _smart_ro_registry_device())
+
+    assert isinstance(device, CulliganIoTDevice)
+    assert device.name == "Smart RO"
+    assert device.device_serial_number == "SRO1-0000AC000W024945974"
+    assert device.device_model_number == "SRO1"
+    assert device.software_version == "1.2.3"
+    assert device.region == "US"
+    assert device.is_online is True
+    assert device.set_command_payload("bypass.permanent.on", True) is None
+
+
+def test_get_devices_classifies_smart_ro_separately_from_softeners():
+    api = _api_with_registry([_smart_ro_registry_device(), _smart_he_registry_device()])
+
+    ro_device, softener_device = CulliganApi.get_devices(api)
+
+    assert isinstance(ro_device, CulliganIoTRO)
+    assert isinstance(softener_device, CulliganIoTSoftener)
+
+
+def test_async_get_devices_classifies_smart_ro_separately_from_softeners():
+    api = _api_with_registry([_smart_ro_registry_device(), _smart_he_registry_device()])
+
+    ro_device, softener_device = asyncio.run(CulliganApi.async_get_devices(api))
+
+    assert isinstance(ro_device, CulliganIoTRO)
+    assert isinstance(softener_device, CulliganIoTSoftener)
+
+
+def test_sro_serial_prefix_is_classified_as_ro_even_with_generic_name():
+    api = _api_with_registry([_smart_ro_registry_device(name="Reverse Osmosis System")])
+
+    [device] = CulliganApi.get_devices(api)
+
+    assert isinstance(device, CulliganIoTRO)


### PR DESCRIPTION
## Summary
- add a read-only `CulliganIoTRO` device class for Smart RO / reverse-osmosis devices
- classify Smart RO devices explicitly from registry metadata instead of leaving them as generic `CulliganIoTDevice`
- keep RO command support intentionally disabled until command semantics are known

## Test Plan
- `PYTHONPATH=src python -m pytest -q`
- `python -m compileall -q src`

## Context
This supports the Home Assistant integration PR feedback that Smart RO support should be modeled in the underlying library rather than inferred from generic IoT devices.